### PR TITLE
Update cloudbuild.yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -21,7 +21,7 @@ steps:
         "deploy", "releases", "create", "rel-${SHORT_SHA}",
         "--delivery-pipeline", "pop-stats-pipeline",
         "--region", "us-central1",
-        "--annotations", "commitId=${REVISION_ID}", “prlink=https://github.com/nateaveryg/pop-kustomize/commit/${COMMIT_SHA}”,
+        "--annotations", "commitId=${REVISION_ID}, prlink=https://github.com/nateaveryg/pop-kustomize/commit/${COMMIT_SHA}”,
         "--images", "pop-stats=us-central1-docker.pkg.dev/$PROJECT_ID/pop-stats/pop-stats:${COMMIT_SHA}"
       ]
 images:


### PR DESCRIPTION
Modified line 24 (Annotation) to correct the syntax.  All key value pairs appear to be in the same set of quote marks according to the documentation.

gcloud deploy releases create --annotations="from_target=test,status=stable"

documentation link: https://cloud.google.com/sdk/gcloud/reference/deploy/releases/create